### PR TITLE
Fix INSERTs - column names and value escaping

### DIFF
--- a/export_sqlite_grt.py
+++ b/export_sqlite_grt.py
@@ -305,7 +305,7 @@ def exportSQLite(cat):
                             'Error', 'Unrecognized column in inserts')
 
             out.write('INSERT INTO %s(' % dq(tbl.name))
-            for i in range(last_column):
+            for i in range(last_column + 1):
                 if i > 0:
                     out.write(',')
                 out.write(dq(tbl.columns[i].name))
@@ -316,7 +316,7 @@ def exportSQLite(cat):
             columns_values = columns_values[9:]
 
             out.write(') VALUES(')
-            out.write(columns_values.replace("'", "''"))
+            out.write(columns_values.replace("\\'", "''"))
             out.write('\n')
 
     def order_tables(out, db_name, schema, unordered, respect_deferredness):


### PR DESCRIPTION
Should fix generated INSERT statements. They were missing last table column (INSERT INTO table (id) VALUES (1,'text')), and quote escaping didn't work (VALUES(''quo\''te'')).

Here is a dead simple test Workbench model: https://www.dropbox.com/s/gwatl81vd49t84d/wb.mwb

I am new to both Python and Workbench plugins so maybe it can be solved differently, feel free to reject and correct yourself.
BTW thanks for rewriting the plugin from the old version!
